### PR TITLE
Add proper caching to euler14

### DIFF
--- a/math/euler14.hoon
+++ b/math/euler14.hoon
@@ -3,31 +3,32 @@
 ::
 ::::  /hoon/euler14/try/
   ::
-=<  (longcol 1.000.000) :: 1mil runs far too slowly uncached
+=<  (longcol 1.000.000) :: With a manual cache, many times faster 
 ::
 ::::  ~haptem-fopnys
   ::
 |%
  
 ++  collatz :: given a, returns the number of steps needed to reach 1
-  |=  [a=@u]
-  ~+
+  |=  [a=@u cache=(map ,@u ,@u)]
   =+  [curr=a len=1]
   |-  ^-  @u
   ?:  =(curr 1)
     len
+  ?:  (~(has by cache) curr) :: if the len is cached...
+    (add (dec len) (~(got by cache) curr)) :: return the len + cached len
   ?:  =((mod curr 2) 0)
     $(curr (div curr 2), len +(len))
   $(curr (add (mul curr 3) 1), len +(len))
 
 ++  longcol :: find the longest collatz sequence under a
   |=  [a=@u]
-  =+  [len=0 num=0 acc=1]
+  =+  [len=0 num=0 acc=1 cache=(mo [[2 1] [4 2] ~])]
   |-  ^-  [@u @u]
-    =+  col=(collatz acc)
+    =+  col=(collatz acc cache)
   ?:  =(acc a)
     [num len]
   ?:  (lte len col)
-    $(len col, num acc, acc +(acc))
-  $(acc +(acc))
+    $(len col, num acc, acc +(acc), cache (~(put by cache) acc col)) 
+  $(acc +(acc), cache (~(put by cache) acc col))
 --


### PR DESCRIPTION
The memoization rune wasn't being applied since the `len` variable under collatz is nearly always different.
I actually had this manual cache at first, but someone in :chat mentioned there was a rune for memoization which I used instead.
It now runs locally in 1m30s opposed to around 11m.
