### PR TITLE
removes pong ++coup printf - adding it is one of the exercises

### DIFF
--- a/gall/pong/app/examples/pong.hoon
+++ b/gall/pong/app/examples/pong.hoon
@@ -20,5 +20,5 @@
   ~&  [%receiving (@t arg)]
   [~ +>.$]
 ::
-++  coup  |=(* ~&(%poke-resolved [~ +>.$]))
+++  coup  |=(* [~ +>.$])
 --


### PR DESCRIPTION
Specifically, the second exercise (see the bottom of the page here: http://urbit.org/docs/arvo/network/)
