### PR TITLE
Fix paths in commands to `cp` examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If your Urbit was installed at `/urbit/path` now you can find your
 
 To copy in all the generators:
 
-    cp -r /examples/path/dojo/* /urbit/path/your-urbit/sandbox/
+    cp -r /examples/path/dojo/*/* /urbit/path/your-urbit/sandbox/
 
 To run your first generator:
 
@@ -33,7 +33,7 @@ To run your first generator:
 
 To copy in all the web pages:
 
-    cp -r /examples/path/web/* /urbit/path/your-urbit/sandbox/
+    cp -r /examples/path/web/*/* /urbit/path/your-urbit/sandbox/
 
 You should be able to find them at
 `http://localhost:8080/pages/examples/1` or similar.
@@ -44,7 +44,7 @@ Have your Urbit serve from the `%examples` desk:
 
 To copy in all the apps:
 
-    cp -r /examples/path/gall/* /urbit/path/your-urbit/sandbox/
+    cp -r /examples/path/gall/*/* /urbit/path/your-urbit/sandbox/
 
 Apps are also inside `examples/` directories, but we use `-`.
 


### PR DESCRIPTION
Current paths copy the files incorrectly to a ship.

Example, with generators:

+
/~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser/sandbox/2/hel
lo/gen/examples/hello/hoon
...

instead of

+
/~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser/sandbox/3/gen/ex
amples/hello/hoon
...

With web:

+
/~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser/sandbox/4/1/w
eb/pages/examples/1/hoon
...

instead of

+
/~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser/sandbox/5/web
/pages/examples/1/hoon
...