### PR TITLE
Write stuff

### DIFF
--- a/dojo/euler4/gen/examples/euler4.hoon
+++ b/dojo/euler4/gen/examples/euler4.hoon
@@ -19,21 +19,21 @@
 ::
 |%
 ++  largest-palindrome
-  |=  {a/@u b/@u}
-  =|  p/@u                                              :: palindrome.
-  |-  ^-  @u
-  ?>  &((lth a 1.000) (lth b 1.000))                    :: three-digit
-  ?>  &((gte a 100) (gth b 100))                        :: numbers.
-  ?:  (lth (mul a b) p)
-    p
-  %=  $
-    p  |-  ^-  @u
-       ?:  (lth (mul a b) p)
-         p
+  |=  {a/@u b/@u}                                       :: gate, takes cell nums
+  =|  p/@u                                              :: palindr. var, set l8r
+  |-  ^-  @u                                            :: loop, produce a num:
+  ?>  &((lth a 1.000) (lth b 1.000))                    :: assert (sure) a&b are
+  ?>  &((gte a 100) (gth b 100))                        ::  three-digit numbers.
+  ?:  (lth (mul a b) p)                                 :: if a*b < p,
+    p                                                   :: produce p
+  %=  $                                                 :: otherwise, call loop:
+    p  |-  ^-  @u                                       :: p -> prod. loop. num:
+       ?:  (lth (mul a b) p)                            :: if a*b < p
+         p                                              :: produce p.
        ?:  =(<(mul a b)> (flop <(mul a b)>))            :: <foo> = list of chars
-         (mul a b)
-       $(b (dec b))
-    a  (dec a)
+         (mul a b)                                      :: ^if palinr., prod a*b
+       $(b (dec b))                                     :: else, call loop w b-1
+    a  (dec a)                                          :: a ->  a - 1.
   ==
 --
 

--- a/dojo/euler4/gen/examples/euler4.hoon
+++ b/dojo/euler4/gen/examples/euler4.hoon
@@ -1,0 +1,41 @@
+::  Project Euler 4
+::  https://projecteuler.net/problem=4
+::
+::  > A palindromic number reads the same both ways. The largest palindrome made
+::  > from the product of two 2-digit numbers is 9009 = 91 × 99.
+::  > Find the largest palindrome made from the product of two 3-digit numbers.
+::
+::  Run in :dojo with `+examples/euler4`.
+::
+::  /gen/examples/euler4
+::
+/?  310
+::
+!:
+::
+:-  %say  |=  *
+:-  %noun
+=<  (largest-palindrome [999 999])
+::
+|%
+++  largest-palindrome
+  |=  {a/@u b/@u}
+  =|  p/@u                                              :: palindrome.
+  |-  ^-  @u
+  ?>  &((lth a 1.000) (lth b 1.000))                    :: three-digit
+  ?>  &((gte a 100) (gth b 100))                        :: numbers.
+  ?:  (lth (mul a b) p)
+    p
+  %=  $
+    p  |-  ^-  @u
+       ?:  (lth (mul a b) p)
+         p
+       ?:  =(<(mul a b)> (flop <(mul a b)>))            :: <foo> = list of chars
+         (mul a b)
+       $(b (dec b))
+    a  (dec a)
+  ==
+--
+
+:: > +examples/euler4
+:: 906.609

--- a/dojo/euler9/gen/examples/euler9.hoon
+++ b/dojo/euler9/gen/examples/euler9.hoon
@@ -18,19 +18,19 @@
 ::
 |%
 ++  find-pythagorean-triplet-abc-sum-eq-one-thousand
-  |=  {a/@u b/@u c/@u}                                  :: gate, takes 3 numbers
+  |=  {a/@u b/@u c/@u}                                  :: gate takes 3-num cell
   |-  ^-  @u                                            :: loop, prod is 1 num.
   ?:  ?!  =((add (add a b) c) 1.000)                    :: if a+b+c not= 1000,
     a                                                   :: produce a.
-  %=  $                                                 :: else, call loop.
+  %=  $                                                 :: else, call loop:
     a  |-  ^-  @u                                       :: a -> inner loop prod:
        ?:  =((add (mul a a) (mul b b)) (mul c c))       :: if abc are pyth. trip
-         ~&  [a b c]                                    :: prints cell [a b c].
-         (mul (mul a b) c)                              :: produce abc.
+         ~&  [a b c]                                    :: println cell [a b c].
+         (mul (mul a b) c)                              :: & produce abc.
        ?:  (lth c b)                                    :: else, if no combos =,
          +(a)                                           :: increment a (reloop).
-       $(b +(b), c (dec c))                             :: else, this loop +b -c
-    c  (dec c)                                          :: c -> decrement c.
+       $(b +(b), c (dec c))                             :: else, loop w b+1 c-1.
+    c  (dec c)                                          :: c -> decrement c, c=1
   ==
 --
 

--- a/dojo/euler9/gen/examples/euler9.hoon
+++ b/dojo/euler9/gen/examples/euler9.hoon
@@ -1,0 +1,39 @@
+::  Project Euler 9
+::  https://projecteuler.net/problem=9
+::
+::  > A Pythagorean triplet is a set of three natural numbers, a < b < c, for
+::  > which,
+::  > >             a2 + b2 = c2
+::  > For example, 3^2 + 4^2 = 9 + 16 = 25 = 5^2.
+::  > There exists exactly one Pythagorean triplet for which a + b + c = 1000.
+::  > Find the product abc.
+::
+/?  310
+::
+!:
+::
+:-  %say  |=  *
+:-  %noun
+=<  (find-pythagorean-triplet-abc-sum-eq-one-thousand [1 1 998])
+::
+|%
+++  find-pythagorean-triplet-abc-sum-eq-one-thousand
+  |=  {a/@u b/@u c/@u}                                  :: gate, takes 3 numbers
+  |-  ^-  @u                                            :: loop, prod is 1 num.
+  ?:  ?!  =((add (add a b) c) 1.000)                    :: if a+b+c not= 1000,
+    a                                                   :: produce a.
+  %=  $                                                 :: else, call loop.
+    a  |-  ^-  @u                                       :: a -> inner loop prod:
+       ?:  =((add (mul a a) (mul b b)) (mul c c))       :: if abc are pyth. trip
+         ~&  [a b c]                                    :: prints cell [a b c].
+         (mul (mul a b) c)                              :: produce abc.
+       ?:  (lth c b)                                    :: else, if no combos =,
+         +(a)                                           :: increment a (reloop).
+       $(b +(b), c (dec c))                             :: else, this loop +b -c
+    c  (dec c)                                          :: c -> decrement c.
+  ==
+--
+
+:: > +examples/euler9
+:: [200 375 425]
+:: 31.875.000

--- a/libs/sorts/lib/sorts.hoon
+++ b/libs/sorts/lib/sorts.hoon
@@ -1,51 +1,71 @@
 ::  arms accessible in dojo after `/+  sorts` (two spaces (`gap`) in between)
 ::  try `test:sorts`
 ::
-::  /libs/sorts
+::  /lib/sorts
 ::
-/?    314
+/?    310
 ::
 !:
 ::
 |%
-++  test  [(merge-sort [10 5 4 6 ~]) (bubble-sort [10 5 4 6 ~])]
+++  test  :*  (insertion-sort [10 5 4 6 ~])
+              (bubble-sort [10 5 4 6 ~])
+              (merge-sort [10 5 4 6 ~])
+          ==
 ::
-++  sort
-  |=  [liz=(list ,@ud)]
-  ^+  liz
-  ?~  liz  ~
-  =+  ^-  state=[[leftside=(list ,@ud)] [bubble=@u] [rightside=(list ,@ud)]]
-      [*(list ,@ud) i.liz t.liz]
-  |-
-  ?~  rightside.state
-    [bubble.state ^$(liz leftside.state)]       ::  recurse with biggest bubbled out
-  ?:  (gth bubble.state i.rightside.state)
-    $(state [[i.rightside.state leftside.state] [bubble.state] [t.rightside.state]])  ::  have to prepend
-  $(state [[bubble.state leftside.state] [i.rightside.state] [t.rightside.state]])    ::  the new bubble
+++  insertion-sort
+  |=  a/(list @u)                                       :: gate, list of numbers
+  =/  b/(list @u)  ~                                    :: var, b = empty list.
+  |-  ^-  (list @u)                                     :: loop, prod. list nums
+  ?~  a  b                                              :: ifno a (~), produce b
+  %=  $                                                 :: else, call loop:
+    a  t.a                                              :: a->tail a (~ if none)
+    b  |-  ^-  (list @u)                                :: b->loop prod, list @s
+       ?~  b  [i.a ~]                                   :: ifno b, prod. head a.
+       ?:  (lth i.a i.b)                                :: else,if head-a<head-b
+         [i.a b]                                        :: prod. cell [head-a b]
+       [i.b $(b t.b)]                                   :: else, prod. i.b, loop
+  ==
 ::
 ++  bubble-sort
-  |=  [a=(list ,@ud)]
-  (flop (sort a))
+  |=  a/(list @u)                                       :: gate, list of numbers
+  =/  s/@u  (lent a)                                    :: var, "surface".
+  =/  c/@u  0                                           :: var, counter.
+  |-  ^-  (list @u)                                     :: loop, produce list @s
+  ?:  =(s 1)                                            :: if surface=1, sorted,
+    a                                                   :: so produce a.
+  %=  $                                                 :: else, call loop:
+    a  |-  ^-  (list @u)                                :: a->loop, list of nums
+       ?~  a  ~                                         :: disambiguates a
+       ?~  t.a  [i.a ~]                                 :: disambiguates t.a
+       ?:  =(+(c) s)                                    :: rest sorted if +(c)=s
+         a                                              :: so produce a.
+       ?:  (gth i.a i.t.a)                              :: else, if head greater
+         [i.t.a $(a [i.a t.t.a], c +(c))]               :: swap, loop w tail,c+1
+       [i.a $(a t.a, c +(c))]                           :: else prod. head, loop
+    s  (dec s)                                          :: s - > dec s, s - 1.
+  ==
 ::
 ++  merge-sort
-  |=  [liz=(list ,@ud)]
-  ?:  (lth (lent liz) 2)
-    liz
-  =+  mid=(div (lent liz) 2)
-  (merge (merge-sort (scag mid liz)) (merge-sort (slag mid liz)))
+  |=  a/(list @u)                                       :: gate, list of numbers
+  ?:  (lth (lent a) 2)                                  :: if <2 elems, "sorted"
+    a                                                   :: so produce a.
+  =+  mid=(div (lent a) 2)                              :: else pin mid->lenta/2
+  %-  merge                                             :: call merge
+  :-  (merge-sort (scag mid a))                         :: with cons-cell l list
+      (merge-sort (slag mid a))                         ::  and right list.
 ::
 ++  merge
-  |=  [left=(list ,@ud) right=(list ,@ud)]
-  =+  merged=*(list ,@ud)
-  |-
-  ::need ?= for type system to let us retrieve head in lines 34, 35
-  ?.  ?|(?=(~ left) ?=(~ right))
-    ?:  (gth i.left i.right)
-      $(merged [i.right merged], right t.right)
-    $(merged [i.left merged], left t.left)
-  ?^  left
-    $(merged [i.left merged], left t.left)
-  ?^  right
-    $(merged [i.right merged], right t.right)
-  (flop merged)  ::  both are empty; flop because hoon only allows prepending
+  |=  {l/(list @u) r/(list @u)}                         :: gate, two lists/ nums
+  =|  merged/(list @u)                                  :: newvar merged,set l8r
+  |-  ^-  (list @u)                                     :: loop, prod. list nums
+  ?.  |(?=($~ l) ?=($~ r))                              :: unless l or r are nil
+    ?:  (gth i.l i.r)                                   :: if l head > r head,
+      $(merged [i.r merged], r t.r)                     :: call loop with <-.
+    $(merged [i.l merged], l t.l)                       :: else, call loop w/ <-
+  ?^  l                                                 :: if left is a cell,
+    $(merged [i.l merged], l t.l)                       :: call loop  with <-.
+  ?^  r                                                 :: else, if r is a cell,
+    $(merged [i.r merged], r t.r)                       :: call loop with <-.
+  (flop merged)                                         :: else prod mrgd revrsd
 --


### PR DESCRIPTION
Add Project Euler 4 and 9, and add insertion sort to our example sorting library. Additionally add correct commenting format, annotating the code line-by-line. Eventually will update rest of examples to same commentary format, i.e. the same format used in new `zuse` and `jael` (a @cgyarvin  request).