### PR TITLE
Updates links at top of ford hoon examples

### DIFF
--- a/web/pages/ford/1.hoon
+++ b/web/pages/ford/1.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 1
-::    accessible at http://localhost:8080/pages/ford/1
+::    accessible at http://localhost:8443/~~/pages/ford/1
 ::
 ::::  /hook/hymn/ford1/pub
   ::

--- a/web/pages/ford/1.hoon
+++ b/web/pages/ford/1.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 1
-::    accessible at http://localhost:8080/home/pub/ford1
+::    accessible at http://localhost:8080/pages/ford/1
 ::
 ::::  /hook/hymn/ford1/pub
   ::

--- a/web/pages/ford/10.hoon
+++ b/web/pages/ford/10.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 10
-::  accessible at http://localhost:8080/pages/ford/10
+::  accessible at http://localhost:8443/~~/pages/ford/10
 ::
 ::  /hook/hymn/ford10/pub
 ::

--- a/web/pages/ford/10.hoon
+++ b/web/pages/ford/10.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 10
-::  accessible at http://localhost:8080/home/pub/ford10
+::  accessible at http://localhost:8080/pages/ford/10
 ::
 ::  /hook/hymn/ford10/pub
 ::

--- a/web/pages/ford/11.hoon
+++ b/web/pages/ford/11.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 11
-::  accessible at http://localhost:8080/pages/ford/11
+::  accessible at http://localhost:8443/~~/pages/ford/11
 ::
 ::  /hook/hymn/ford11/pub
 ::

--- a/web/pages/ford/11.hoon
+++ b/web/pages/ford/11.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 11
-::  accessible at http://localhost:8080/home/pub/ford11
+::  accessible at http://localhost:8080/pages/ford/11
 ::
 ::  /hook/hymn/ford11/pub
 ::

--- a/web/pages/ford/12.hoon
+++ b/web/pages/ford/12.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 12
-::  accessible at http://localhost:8080/home/pub/ford12
+::  accessible at http://localhost:8080/pages/ford/12
 ::
 ::  /hook/hymn/ford12/pub
 ::

--- a/web/pages/ford/12.hoon
+++ b/web/pages/ford/12.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 12
-::  accessible at http://localhost:8080/pages/ford/12
+::  accessible at http://localhost:8443/~~/pages/ford/12
 ::
 ::  /hook/hymn/ford12/pub
 ::

--- a/web/pages/ford/2.hoon
+++ b/web/pages/ford/2.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 2
-::    accessible at http://localhost:8080/home/pub/ford2
+::    accessible at http://localhost:8080/pages/ford/2
 ::
 ::::  /hook/hymn/ford2/pub
   ::

--- a/web/pages/ford/2.hoon
+++ b/web/pages/ford/2.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 2
-::    accessible at http://localhost:8080/pages/ford/2
+::    accessible at http://localhost:8443/~~/pages/ford/2
 ::
 ::::  /hook/hymn/ford2/pub
   ::

--- a/web/pages/ford/3.hoon
+++ b/web/pages/ford/3.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 3
-::    accessible at http://localhost:8080/pages/ford/3
+::    accessible at http://localhost:8443/~~/pages/ford/3
 ::
 ::::  /hook/hymn/ford3/pub
   ::

--- a/web/pages/ford/3.hoon
+++ b/web/pages/ford/3.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 3
-::    accessible at http://localhost:8080/home/pub/ford3
+::    accessible at http://localhost:8080/pages/ford/3
 ::
 ::::  /hook/hymn/ford3/pub
   ::

--- a/web/pages/ford/4.hoon
+++ b/web/pages/ford/4.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 4
-::    accessible at http://localhost:8080/home/pub/ford4
+::    accessible at http://localhost:8080/pages/ford/4
 ::
 ::::  /hook/hymn/ford4/pub
   ::

--- a/web/pages/ford/4.hoon
+++ b/web/pages/ford/4.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 4
-::    accessible at http://localhost:8080/pages/ford/4
+::    accessible at http://localhost:8443/~~/pages/ford/4
 ::
 ::::  /hook/hymn/ford4/pub
   ::

--- a/web/pages/ford/5.hoon
+++ b/web/pages/ford/5.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 5
-::    accessible at http://localhost:8080/home/pub/ford5
+::    accessible at http://localhost:8080/pages/ford/5
 ::
 ::::  /hook/hymn/ford5/pub
   ::

--- a/web/pages/ford/5.hoon
+++ b/web/pages/ford/5.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 5
-::    accessible at http://localhost:8080/pages/ford/5
+::    accessible at http://localhost:8443/~~/pages/ford/5
 ::
 ::::  /hook/hymn/ford5/pub
   ::

--- a/web/pages/ford/6.hoon
+++ b/web/pages/ford/6.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 6
-::    accessible at http://localhost:8080/home/pub/ford6
+::    accessible at http://localhost:8080/pages/ford/6
 ::
 ::::  /hook/hymn/ford6/pub
   ::

--- a/web/pages/ford/6.hoon
+++ b/web/pages/ford/6.hoon
@@ -1,5 +1,5 @@
 ::    Ford example 6
-::    accessible at http://localhost:8080/pages/ford/6
+::    accessible at http://localhost:8443/~~/pages/ford/6
 ::
 ::::  /hook/hymn/ford6/pub
   ::

--- a/web/pages/ford/7.hoon
+++ b/web/pages/ford/7.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 7
-::  accessible at http://localhost:8080/home/pub/ford7
+::  accessible at http://localhost:8080/pages/ford/7
 ::
 ::  /hook/hymn/ford7/pub
 ::

--- a/web/pages/ford/7.hoon
+++ b/web/pages/ford/7.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 7
-::  accessible at http://localhost:8080/pages/ford/7
+::  accessible at http://localhost:8443/~~/pages/ford/7
 ::
 ::  /hook/hymn/ford7/pub
 ::

--- a/web/pages/ford/8.hoon
+++ b/web/pages/ford/8.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 8
-::  accessible at http://localhost:8080/pages/ford/8
+::  accessible at http://localhost:8443/~~/pages/ford/8
 ::
 ::  /hook/hymn/ford8/pub
 ::

--- a/web/pages/ford/8.hoon
+++ b/web/pages/ford/8.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 8
-::  accessible at http://localhost:8080/home/pub/ford8
+::  accessible at http://localhost:8080/pages/ford/8
 ::
 ::  /hook/hymn/ford8/pub
 ::

--- a/web/pages/ford/9.hoon
+++ b/web/pages/ford/9.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 9
-::  accessible at http://localhost:8080/pages/ford/9
+::  accessible at http://localhost:8443/~~/pages/ford/9
 ::
 ::  /hook/hymn/ford9/pub
 ::

--- a/web/pages/ford/9.hoon
+++ b/web/pages/ford/9.hoon
@@ -1,5 +1,5 @@
 ::  Ford example 9
-::  accessible at http://localhost:8080/home/pub/ford9
+::  accessible at http://localhost:8080/pages/ford/9
 ::
 ::  /hook/hymn/ford9/pub
 ::


### PR DESCRIPTION
The links at the top of the files /examples/web/pages/ford/[1-12].hoon are incorrect. The updates them to their correct new local url.